### PR TITLE
Only create ressource group if it does not exist

### DIFF
--- a/ARMv2/Deploy-AzureStackonAzureVM.ps1
+++ b/ARMv2/Deploy-AzureStackonAzureVM.ps1
@@ -273,8 +273,12 @@ if ($UseExistingStorageAccount)
 }
 else
 {
-   #Create new Resource Group
-   New-AzResourceGroup -Name $ResourceGroupName -Location $Region
+   #Create new Resource Group if it does not already exist
+   if (!(Get-AzResourceGroup -Name $ResourceGroupName -Location $Region -ErrorAction SilentlyContinue))
+   {
+	   write-verbose -Message "Create Ressource Group"
+	   New-AzResourceGroup -Name $ResourceGroupName -Location $Region
+   }
    $i = 0
    do 
    {

--- a/ARMv2/Deploy-AzureStackonAzureVM.ps1
+++ b/ARMv2/Deploy-AzureStackonAzureVM.ps1
@@ -276,7 +276,7 @@ else
    #Create new Resource Group if it does not already exist
    if (!(Get-AzResourceGroup -Name $ResourceGroupName -Location $Region -ErrorAction SilentlyContinue))
    {
-	   write-verbose -Message "Create Ressource Group"
+	   Write-Verbose -Message "Create Resource Group"
 	   New-AzResourceGroup -Name $ResourceGroupName -Location $Region
    }
    $i = 0


### PR DESCRIPTION
In my organization I'm not allowed to create resource groups. I suggest to change the script so that resource group is only created if it does not already exist. 